### PR TITLE
fix(td): use latest tag in image policy and deployment

### DIFF
--- a/fluxcd/images/image-policy.yaml
+++ b/fluxcd/images/image-policy.yaml
@@ -33,6 +33,8 @@ spec:
   imageRepositoryRef:
     name: td-repository
   digestReflectionPolicy: IfNotPresent
+  filterTags:
+    pattern: '^latest$'
   policy:
     alphabetical:
       order: asc

--- a/td/deployment.yaml
+++ b/td/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: td
-          image: ghcr.io/mvaldes14/task-manager:sha-e4ac5c1@sha256:3e510ec47fc45821cea74b0d66cba19c5a1f96812dfee821b8358279ac155c90 # {"$imagepolicy" : "flux-system:td-policy"}
+          image: ghcr.io/mvaldes14/task-manager:latest # {"$imagepolicy" : "flux-system:td-policy"}
           ports:
             - name: td-port
               containerPort: 5000


### PR DESCRIPTION
The td-policy was using alphabetical ascending order without a tag
filter, causing FluxCD to select old SHA-based tags instead of latest.

Added filterTags with pattern '^latest$' to td-policy so the automation
correctly tracks and applies the latest tag. Reset the deployment image
back to latest so FluxCD automation can manage it going forward.

https://claude.ai/code/session_01VMhXQYQFPB8ggsigiSZEsr